### PR TITLE
ci(repo): adds GitHub Actions worflow for running tests with coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+---
+
+name: CI
+
+on: [push]
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    env:
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --non-interactive --silent
+
+      - name: Setup Code Climate test-reporter
+        run: |
+          wget https://codeclimate.com/downloads/test-reporter/test-reporter-0.7.0-linux-amd64
+          chmod 755 ./test-reporter-0.7.0-linux-amd64
+
+      - name: Run tests with coverage
+        run: |
+          ./test-reporter-0.7.0-linux-amd64 before-build
+          yarn test --coverage
+          ./test-reporter-0.7.0-linux-amd64 after-build


### PR DESCRIPTION
Got a report in CC: https://codeclimate.com/repos/61487d133aebbd01a000b141/settings/test_reports/614888ca8c301e568e0060d8

and GA says:

![Screenshot 2021-09-20 at 15 14 24](https://user-images.githubusercontent.com/2794190/134008446-72b53256-17f3-4a94-954b-4e045db82211.png)
