### PR TITLE
fix(events): partner events

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -64,14 +64,14 @@ type DreamsEvent = IdTokenDidExpireEvent |
                    ShareEvent;
 
 type AccountProvisionInitiatedEvent = {
-  name: partnerEvents.accountProvisionInitiated;
+  event: partnerEvents.accountProvisionInitiated;
   message: {
     requestId: string;
   }
 }
 
 type InvestmentAccountProvisionInitiatedEvent = {
-  name: partnerEvents.investmentAccountProvisionInitiated;
+  event: partnerEvents.investmentAccountProvisionInitiated;
   message: {
     requestId: string;
     accountId: string;
@@ -84,12 +84,12 @@ type UpdateTokenMessage = {
 }
 
 type UpdateTokenEvent = {
-  name: partnerEvents.updateToken;
+  event: partnerEvents.updateToken;
   message: UpdateTokenMessage
 }
 
 type NavigateToEvent = {
-  name: partnerEvents.navigateTo;
+  event: partnerEvents.navigateTo;
   message: {
     location: string;
   }

--- a/src/messageHandler.ts
+++ b/src/messageHandler.ts
@@ -63,7 +63,7 @@ class MessageHandler {
   */
   postUpdateToken = (message: UpdateTokenMessage) => {
     const event: UpdateTokenEvent = {
-      name: partnerEvents.updateToken,
+      event: partnerEvents.updateToken,
       message
     }
 
@@ -75,7 +75,7 @@ class MessageHandler {
   */
   postAccountProvisionInitiated = (message: Message) => {
     const event: AccountProvisionInitiatedEvent = {
-      name: partnerEvents.accountProvisionInitiated,
+      event: partnerEvents.accountProvisionInitiated,
       message
     }
 
@@ -89,7 +89,7 @@ class MessageHandler {
   */
   postInvestmentAccountProvisionInitiated = (message: InvestmentAccountProvisionRequestedMessage) => {
     const event: InvestmentAccountProvisionInitiatedEvent = {
-      name: partnerEvents.investmentAccountProvisionInitiated,
+      event: partnerEvents.investmentAccountProvisionInitiated,
       message
     }
 
@@ -101,7 +101,7 @@ class MessageHandler {
   */
   navigateTo = (location: string) => {
     const event: NavigateToEvent = {
-      name: partnerEvents.navigateTo,
+      event: partnerEvents.navigateTo,
       message: { location }
     }
 


### PR DESCRIPTION
BREAKING CHANGE: new PartnerEvent types

The application bridge expects the key to be `event`, not `name`, see: https://github.com/dreamstechnology/dreams-enterprise/blob/main/app/packs/controllers/application_bridge_controller.ts#L115-L127